### PR TITLE
Update bin/release

### DIFF
--- a/bin/release
+++ b/bin/release
@@ -22,7 +22,7 @@ description=$(echo "$description" | sed 's/\n/\\n/g') # Escape line breaks to pr
 # Create a release
 echo $description
 echo "Create a release ..."
-release=$(curl -X POST -H "Authorization:token $token" --data "{\"tag_name\": \"$tag\", \"target_commitish\": \"master\", \"name\": \"$name\", \"body\": \"$description\", \"draft\": false, \"prerelease\": true}" https://api.github.com/repos/enspirit/harpocrates/releases)
+release=$(curl -X POST -H "Authorization:token $token" --data "{\"tag_name\": \"$tag\", \"target_commitish\": \"master\", \"name\": \"$name\", \"body\": \"$description\", \"draft\": false, \"prerelease\": false}" https://api.github.com/repos/enspirit/harpocrates/releases)
 
 # Extract the id of the release from the creation response
 id=$(echo "$release" | sed -n -e 's/"id":\ \([0-9]\+\),/\1/p' | head -n 1 | sed 's/[[:blank:]]//g')


### PR DESCRIPTION
Turn off prerelease. Will decide in the future if we need a switch to toggle it. But now pretend all releases are production-ready.

![Capture d’écran de 2021-08-11 09-47-01](https://user-images.githubusercontent.com/22132947/129008787-6012b6eb-c311-49d4-87f5-7b720168cd6b.png)
